### PR TITLE
chore(app): additional flows to test deploy error

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,18 @@
+name: Kestra CI/CD
+
+on: [push]
+
+jobs:
+  # Start by validating all kestra resources
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Deploy `app.htch.assets.comms` flows"
+        uses: kestra-io/deploy-action@v0.14.0
+        with:
+          namespace: app.htch.comms
+          directory: ./flows
+          resource: flow
+          server: ${{ secrets.KESTRA_HOST_MAIN }}
+          user: ${{ secrets.KESTRA_USER_MAIN }}
+          password: ${{ secrets.KESTRA_PASSWORD_MAIN }}

--- a/flows/alert.yml
+++ b/flows/alert.yml
@@ -1,0 +1,33 @@
+id: alert-success
+namespace: app.htch.comms
+
+variables:
+  discord_webhook_url: "http://google.com"
+  deployment_url: "http://google.com"
+  instance_name: "nope"
+
+description: |
+  Reports successes of processing
+
+tasks:
+  - id: discord
+    type: "io.kestra.plugin.fs.http.Request"
+    uri: "{{ vars.discord_webhook_url }}"
+    method: "POST"
+    contentType: "application/json"
+    body: |
+      {
+        "content": "[{{ vars.instance_name }}] We just helped someone view a model. No big deal. See [Workflow]({{ vars.deployment_url }}/ui/executions/{{ trigger.namespace }}/{{ trigger.flowId }}/{{ trigger.executionId }}/gantt) ✅",
+        "flags": 4096
+      }
+
+triggers:
+  - id: listen
+    type: io.kestra.core.models.triggers.types.Flow
+    conditions:
+      - type: io.kestra.core.models.conditions.types.ExecutionStatusCondition
+        in:
+          - SUCCESS
+      - type: io.kestra.core.models.conditions.types.ExecutionFlowCondition
+        flowId: pipeline-main
+        namespace: app.htch.assets.pipelines

--- a/flows/kafka.yml
+++ b/flows/kafka.yml
@@ -1,0 +1,44 @@
+id: kafka-produce
+namespace: app.htch.comms
+
+# TEMPORARY: until Github Action catches up with Kestra
+# labels:
+#   - key: owner
+#     value: michele@htch.app
+#   - key: team
+#     value: comms
+
+variables:
+  kafka_bootstrap_endpoint: "http://google.com"
+  kafka_username: "nope"
+  kafka_password: "nope"
+
+inputs:
+  - name: topic
+    type: STRING
+    defaults: pipelinetest
+    required: true
+    description: |
+      Name of topic to send message to.
+
+  - name: body
+    type: STRING
+    defaults: '{ "message": "hello" }'
+    required: true
+    description: |
+      Body of message.
+
+tasks:
+  - id: produce
+    type: io.kestra.plugin.kafka.Produce
+    topic: "{{ inputs.topic }}"
+    from:
+      value: "{{ inputs.body }}"
+    properties:
+      bootstrap.servers: "{{ vars.kafka_bootstrap_endpoint }}"
+      sasl.mechanism: "SCRAM-SHA-512"
+      security.protocol: "SASL_SSL"
+      sasl.jaas.config: |
+        org.apache.kafka.common.security.scram.ScramLoginModule required username="{{ vars.kafka_username }}" password="{{ vars.kafka_password }}";
+    keySerializer: STRING
+    valueSerializer: STRING


### PR DESCRIPTION
- These are flows in the `comms` namespace that's breaking. Something in here is causing GA deploy to break with the `remote-api` error.

- Added example deploy workflow triggering the error